### PR TITLE
feat: sorting_member on course member page

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9846,6 +9846,11 @@ ja:
         role_to_search: 制限付きのロール検索
         search_people: メンバーの検索
         title_add_people: メンバーの追加
+        sort_by_name: 名前で並び替え
+        sort_by_email: メールで並び替え
+        sort_by_last_login: 最終アクセス日時で並び替え
+        sort_by_sis_id: SIS ID で並び替え
+        sort_by_integration_id: 統合 ID で並び替え
       invitations_view: 
         accepted_invitation: "%{name}コースに参加するための招待状をすでに受け取っていますが、必要があれば招待状を再送信することができます。"
         admin_invitation_unaccepted: "%{name} はまだコースへの招待を受諾していません。招待が送信された時刻: %{time}"

--- a/lib/user_search.rb
+++ b/lib/user_search.rb
@@ -96,7 +96,25 @@ module UserSearch
       order = " DESC NULLS LAST, id DESC" if options[:order] == "desc"
       case options[:sort]
       when "last_login"
-        users_scope.select("users.*").order(Arel.sql("last_login#{order}"))
+        order = " DESC NULLS LAST, id DESC" if options[:order] != "asc"
+        case context
+        when Account
+         users_scope = users_scope
+         .joins("LEFT JOIN #{Pseudonym.quoted_table_name} p ON p.user_id = users.id AND p.workflow_state = 'active'")
+         .select("users.*, MAX(p.last_login_at) AS last_login")
+         .group("users.id") # 必要に応じて group by
+         users_scope.order(Arel.sql("last_login #{order}"))  
+        when Course
+         users_scope = users_scope
+         .joins("LEFT JOIN #{Enrollment.quoted_table_name} e2 ON e2.user_id = users.id AND e2.course_id = #{context.id}")
+         .select("users.*, MAX(e2.last_activity_at) AS last_activity")
+         .group("users.id") # 必要に応じて group by
+         users_scope.order(Arel.sql("last_activity #{order}"))  
+        else # Since last_login cannot be detected, order by username as a failsafe.
+          users_scope.select("users.*").order_by_sortable_name(direction: (options[:order] == "desc") ? :descending : :ascending)
+        end
+#      when "last_login"
+#        users_scope.select("users.*").order(Arel.sql("last_login#{order}"))
       when "username"
         users_scope.select("users.*").order_by_sortable_name(direction: (options[:order] == "desc") ? :descending : :ascending)
       when "email"

--- a/ui/features/roster/backbone/views/RosterView.jsx
+++ b/ui/features/roster/backbone/views/RosterView.jsx
@@ -40,6 +40,8 @@ export default class RosterView extends Backbone.View {
 
     this.child('roleSelectView', '[data-view=roleSelect]')
 
+    this.child('sortSelectView', '[data-view=sortSelect]')
+
     this.child('resendInvitationsView', '[data-view=resendInvitations]')
 
     this.child('rosterTabsView', '[data-view=rosterTabs]')

--- a/ui/features/roster/backbone/views/SortSelectView.js
+++ b/ui/features/roster/backbone/views/SortSelectView.js
@@ -1,0 +1,16 @@
+// SortSelectView.js
+import Backbone from '@canvas/backbone'
+
+export default class SortSelectView extends Backbone.View {
+  events() {
+    return {
+      'change': 'onChange'
+    }
+  }
+
+  onChange(e) {
+    const value = this.$el.val()
+    this.collection.setParam('sort', value)
+    // fetch は RosterView が setParam を listen しているので自動実行！
+  }
+}

--- a/ui/features/roster/index.js
+++ b/ui/features/roster/index.js
@@ -24,6 +24,7 @@ import RoleSelectView from './backbone/views/RoleSelectView'
 import rosterUsersTemplate from './jst/rosterUsers.handlebars'
 import RosterUserCollection from './backbone/collections/RosterUserCollection'
 import RolesCollection from './backbone/collections/RolesCollection'
+import SortSelectView from './backbone/views/SortSelectView'
 import SectionCollection from '@canvas/sections/backbone/collections/SectionCollection'
 import GroupCategoryCollection from '@canvas/groups/backbone/collections/GroupCategoryCollection'
 import InputFilterView from '@canvas/backbone-input-filter-view'
@@ -74,6 +75,9 @@ const roleSelectView = new RoleSelectView({
   collection: users,
   rolesCollection,
 })
+const sortSelectView = new SortSelectView({
+  collection: users
+})
 const resendInvitationsView = new ResendInvitationsView({
   model: course,
   resendInvitationsUrl: ENV.resend_invitations_url,
@@ -96,6 +100,7 @@ const app = new RosterView({
   rosterTabsView,
   inputFilterView,
   roleSelectView,
+  sortSelectView, // 追加！
   resendInvitationsView,
   collection: users,
   roles: ENV.ALL_ROLES,

--- a/ui/features/roster/jst/index.handlebars
+++ b/ui/features/roster/jst/index.handlebars
@@ -31,6 +31,7 @@
       aria-label='{{#t "sort_users"}}Sort users by{{/t}}'>
       <option value="username">{{#t "sort_by_name"}}Name{{/t}}</option>
       <option value="email">{{#t "sort_by_email"}}Email{{/t}}</option>
+      <option value="last_login">{{#t "sort_by_last_login"}}Last Login{{/t}}</option>  
       <option value="sis_id">{{#t "sort_by_sis_id"}}SIS ID{{/t}}</option>
       <option value="integration_id">{{#t "sort_by_integration_id"}}Integration ID{{/t}}</option>
     </select>

--- a/ui/features/roster/jst/index.handlebars
+++ b/ui/features/roster/jst/index.handlebars
@@ -25,6 +25,15 @@
       aria-label='{{#t "role_to_search"}}Limit search to role{{/t}}'
       ></select>
 
+    <select
+      name="sort_select"
+      data-view="sortSelect"
+      aria-label='{{#t "sort_users"}}Sort users by{{/t}}'>
+      <option value="username">{{#t "sort_by_name"}}Name{{/t}}</option>
+      <option value="email">{{#t "sort_by_email"}}Email{{/t}}</option>
+      <option value="sis_id">{{#t "sort_by_sis_id"}}SIS ID{{/t}}</option>
+      <option value="integration_id">{{#t "sort_by_integration_id"}}Integration ID{{/t}}</option>
+    </select>
     {{#if permissions.add_users_to_course}}
     {{#if course.concluded}}
     <a


### PR DESCRIPTION
コース画面でメンバーのソート機能の追加

username, email, sis_id, integration_id

のどれかで検索可能

order ascのみで、order descにはこのコミットでは対応していない（API的にはdescもあるので、対応は可能）
日本語化はまだしていない

[2025/07/04]
sortable_nameに強制的に学籍番号・教職員番号を先頭に付与することで、
この機能は不要になりました。
