### PR TITLE
Adds BOM inclusion logic for UTF-8 encoding

### DIFF
--- a/config/initializers/csv_with_bom.rb
+++ b/config/initializers/csv_with_bom.rb
@@ -1,0 +1,17 @@
+Rails.application.config.to_prepare do
+  CSVWithI18n.singleton_class.class_eval do
+    # 既存のメソッドがあるか確認
+    if method_defined?(:include_bom?)
+      alias_method :original_include_bom?, :include_bom?
+      
+      def include_bom?(user, encoding)
+        encoding == "UTF-8" ? true : original_include_bom?(user, encoding)
+      end
+    else
+      # メソッドが存在しない場合は新たに定義
+      def include_bom?(user, encoding)
+        encoding == "UTF-8"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ensures that a Byte Order Mark (BOM) is included when encoding CSV files in UTF-8. This modification addresses potential compatibility issues with applications that expect a BOM for UTF-8 encoded files.
