### PR TITLE
Fix: avoid unintended @@skip_touch_context persistence when @skip_tou…

### DIFF
--- a/config/initializers/active_record.rb
+++ b/config/initializers/active_record.rb
@@ -247,7 +247,9 @@ class ActiveRecord::Base
   end
 
   def touch_context
-    return if @@skip_touch_context ||= false || @skip_touch_context ||= false
+    skip1 = defined?(@@skip_touch_context) ? @@skip_touch_context : false
+    skip2 = @skip_touch_context.nil? ? false : @skip_touch_context
+    return if skip1 || skip2
 
     self.class.connection.after_transaction_commit do
       if respond_to?(:context_type) && respond_to?(:context_id) && context_type && context_id


### PR DESCRIPTION
インスタンス変数 @skip_touch_contextがtrueになると、
touch_contextメソッドにより クラス変数 @@skip_touch_contextもtrueになってしまい、
それ以後、そのプロセスではtouch_contextが無効になってしまう。

結果として、announcementを作成・編集しても、clientのupdated_atが更新されず、
updated_atがredisのキャッシュキーの一部になっていることから、古いキャッシュが残った
ままになり、結果としてannouncementが公開されないままになってしまう。


このPRは、この不具合を改修し、正常にtouch_contextメソッドが呼ばれるようにしています。