### PR TITLE
feat: add BOM for quiz report csv

### DIFF
--- a/app/models/quizzes/quiz_statistics/student_analysis.rb
+++ b/app/models/quizzes/quiz_statistics/student_analysis.rb
@@ -318,7 +318,7 @@ class Quizzes::QuizStatistics::StudentAnalysis < Quizzes::QuizStatistics::Report
         row << submission.score
         csv << row
       end
-    end
+    end.prepend("\uFEFF") # Always prepend UTF-8 BOM to support Excel compatibility
   end
 
   private

--- a/app/models/quizzes/quiz_statistics/student_analysis.rb
+++ b/app/models/quizzes/quiz_statistics/student_analysis.rb
@@ -318,7 +318,7 @@ class Quizzes::QuizStatistics::StudentAnalysis < Quizzes::QuizStatistics::Report
         row << submission.score
         csv << row
       end
-    end.prepend("\uFEFF") # Always prepend UTF-8 BOM to support Excel compatibility
+    end
   end
 
   private

--- a/config/initializers/csv_with_bom.rb
+++ b/config/initializers/csv_with_bom.rb
@@ -15,3 +15,16 @@ Rails.application.config.to_prepare do
     end
   end
 end
+
+# config/initializers/csv_with_bom.rb
+module CSVWithBOM
+  module GenerateWithBOM
+    def generate(*args, &block)
+      result = super
+      result.prepend("\uFEFF") unless result.start_with?("\uFEFF")
+      result
+    end
+  end
+end
+
+CSV.singleton_class.prepend(CSVWithBOM::GenerateWithBOM)


### PR DESCRIPTION
受講者分析のCSVファイルに、常にBOMファイルを付与する

なお、CanvasLMSのアカウント -> 設定 -> 機能オプションの
「対応するスプレッドシートのエクスポートにバイトオーダーマークを含める」
の設定は反映されない。常にBOMファイルをつけます

元の実装が、すでにそのようになっていて、機能オプションとは無関係に
BOMをつけない状態になっていました。

このCSVはキャッシュされてしまうため、先生ごとにBOMをつける・つけないと
処理わけするのが難しいので、このPRでは、一律にBOMをつけています。

ただし、BOM付きのCSVファイルはエクセルは自動でスプレッドシートとして開くことが出来ないようで、
インポートウィザードがたちがあります。そこで「区切り記号付き」を選択し、次のページで区切り文字として「カンマ」
を選択する必要があります

詳しくは
https://monaca.atlassian.net/browse/BUNKYO-20?focusedCommentId=22052
を参照



