### PR TITLE
fix: BUNKYO-21 csv export error when rating

### DIFF
--- a/config/initializers/csv_with_bom.rb
+++ b/config/initializers/csv_with_bom.rb
@@ -19,10 +19,19 @@ end
 # config/initializers/csv_with_bom.rb
 module CSVWithBOM
   module GenerateWithBOM
-    def generate(*args, &block)
-      result = super
-      result.prepend("\uFEFF") unless result.start_with?("\uFEFF")
+    def generate(str = nil, **options, &block)
+      result = super(str, **options, &block)
+
+      if result.is_a?(String)
+        result.prepend("\uFEFF") unless result.start_with?("\uFEFF")
+      else
+        Rails.logger.warn("[CSVWithBOM] CSV.generate returned non-String (#{result.class}) — skipping BOM prepend")
+      end
+
       result
+    rescue => e
+      Rails.logger.error("[CSVWithBOM] Failed to generate CSV with BOM: #{e.class} - #{e.message}")
+      raise
     end
   end
 end


### PR DESCRIPTION
Rubyの組み込みのCSVクラスのgenerateメソッドは
```
    def generate(str=nil, **options)
```
であるため、これに合わせないと、第一引数がなくて、第二引数からがキーバリュー形式で呼ばれたときに
、キーバリュー形式をHashとして、改めてCSV.generateの第一引数として呼んでしまうため、次のエラーが発生する

`no implicit conversion of Hash into String`

実際、今回呼び出しているのは `lib/gradebook_exporter.rb` の 150行目からの

```
    CSVWithI18n.generate(**@options.slice(:encoding, :col_sep, :include_bom)) do |csv|
...
```
という箇所で、**@options.sliceにより、ハッシュを引数展開しているが、第一引数の文字列はない。

しかし、既存のコードだと、ハッシュを引数に展開されたのに、それが再びハッシュとして第一引数として扱ってしまうので、これはstringではないため、先のエラーが発生している

このPRは、オリジナルのCSV.generateと同じ引数をとるように修正し、先の不具合が発生しないようにした

