### PR TITLE
feat: BUNKYO-22 dashboard_course_card_limit initial value is 100

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2991,7 +2991,7 @@ class User < ActiveRecord::Base
     # this terribleness is so we try to make sure that the newest courses show up in the menu
     courses = courses_with_primary_enrollment(:current_and_invited_courses, enrollment_uuid, opts)
               .sort_by { |c| [c.primary_enrollment_rank, Time.zone.now - (c.primary_enrollment_date || Time.zone.now)] }
-              .first(Setting.get("menu_course_limit", "20").to_i)
+              .first(Setting.get("menu_course_limit", "100").to_i)
               .sort_by { |c| [c.primary_enrollment_rank, Canvas::ICU.collation_key(c.name)] }
     favorites = courses_with_primary_enrollment(:favorite_courses, enrollment_uuid, opts)
                 .select { |c| can_favorite.call(c) }

--- a/lib/tasks/db_load_data.rake
+++ b/lib/tasks/db_load_data.rake
@@ -182,7 +182,6 @@ namespace :db do
   task configure_default_settings: :load_environment do
     Setting.set("support_multiple_account_types", "false")
     Setting.set("show_opensource_linkback", "true")
-    Setting.set("menu_course_limit","100")
   end
 
   desc "generate data"

--- a/lib/tasks/db_load_data.rake
+++ b/lib/tasks/db_load_data.rake
@@ -182,6 +182,7 @@ namespace :db do
   task configure_default_settings: :load_environment do
     Setting.set("support_multiple_account_types", "false")
     Setting.set("show_opensource_linkback", "true")
+    Setting.set("menu_course_limit","100")
   end
 
   desc "generate data"


### PR DESCRIPTION
BUNKYO-22:
ダッシュボードに表示されるコースパネルの上限を100にする。


Settingsのmenu_course_limitを変更する修正ではなく、結局、利用時のデフォルト値を100にすることで対応した。
なので、PRを反映して再起動すれば、ダッシュボードに表示されるコースパネルは100になる。
(settingsテーブルに、menu_course_limitはない状態)

```
$ docker-compose down
$ docker-compose up -d
```


