### PR TITLE
Adds jitter to unread counts

### DIFF
--- a/ui/features/navigation_header/react/queries/unreadCountQuery.ts
+++ b/ui/features/navigation_header/react/queries/unreadCountQuery.ts
@@ -38,6 +38,12 @@ export async function getUnreadCount({queryKey, signal}: QueryFunctionContext): 
   if (!unreadCountTypes.includes(unreadCountType))
     throw new Error(`Bad unreadCount type ${unreadCountType}`)
 
+  // Add jitter to spread load using a single random delay (0-3000ms)
+  if (unreadCountType === 'conversations' || unreadCountType === 'release_notes') {
+    const jitter = Math.floor(Math.random() * 5000)
+    await new Promise(resolve => setTimeout(resolve, jitter))
+  }
+
   const path = URL_MAP[unreadCountType]
   // conversations count returns as string 😞    vvvvvvvvvvvvvvv
   const {json} = await doFetchApi<{unread_count: number | string}>({path, fetchOpts})


### PR DESCRIPTION
Implements a jitter mechanism to delay the fetching of unread counts for conversations and release notes.

This spreads the load on the server, mitigating potential spikes
caused by concurrent requests for these counts. The jitter introduces
a random delay of up to 5 seconds before the fetch request is made.
