### PR TITLE
Adds mail network to services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD
     networks:
       - canvas-lms-network
+      - mailnet
     env_file: .env 
 
   jobs:
@@ -68,3 +69,6 @@ services:
 
 networks:
   canvas-lms-network:
+  mailnet:
+    external: true
+    name: mailnet


### PR DESCRIPTION
Configures a new mail network and links it to the
`postgres` and `jobs` services.

This allows these services to communicate with the
mail server, which is a prerequisite for enabling
email functionality.
